### PR TITLE
Fix typos and disconnection event name

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "npm start": "nodemon server.js",
+    "start": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,7 +24,7 @@ io.on('connection', (socket) => {
     });
 
     //Disconnect
-    socket.on('diconnect', () => {
+    socket.on('disconnect', () => {
         console.log('❌ Client disconnected - ', socket.id);
     });
 });

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,4 @@
-# Fronend
+# Frontend
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.3.3.
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "fronend": {
+    "frontend": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -24,7 +24,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/fronend",
+            "outputPath": "dist/frontend",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
@@ -69,10 +69,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "fronend:build:production"
+              "buildTarget": "frontend:build:production"
             },
             "development": {
-              "buildTarget": "fronend:build:development"
+              "buildTarget": "frontend:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -80,7 +80,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "buildTarget": "fronend:build"
+            "buildTarget": "frontend:build"
           }
         },
         "test": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fronend",
+  "name": "frontend",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fronend",
+      "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^17.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fronend",
+  "name": "frontend",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -20,16 +20,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'fronend'`, () => {
+  it(`should have as title 'frontend'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('fronend');
+    expect(app.title).toEqual('frontend');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, fronend');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, frontend');
   });
 });

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -4,7 +4,7 @@ import { SocketService } from './services/socket.service';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   public title = 'Chat App';

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Fronend</title>
+  <title>Frontend</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary
- correct `disconnect` event name in backend server
- fix misspellings for frontend project name
- update Angular component decorator styleUrls
- adjust configs and docs to use the correct name

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Chrome not found)

------
https://chatgpt.com/codex/tasks/task_e_6842d1e61c5083338bc3cfb7cf98602d