### PR TITLE
Add simple network-accessible GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Simple Chat App
+
+This repository contains a minimal Socket.IO chat application with a built-in GUI.
+
+## Running the server
+
+1. Install dependencies:
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+   The server listens on **port 3000**.
+
+## Accessing the GUI
+
+Open a browser and navigate to `http://<server-ip>:3000/` where `&lt;server-ip&gt;` is
+the IP address of the machine running the server. Multiple computers can connect
+to this page and chat in real time.
+
+The GUI allows you to join a room and exchange messages with other users.
+
+## Frontend (optional)
+
+An Angular frontend is included under the `frontend/` directory. It is not
+required for basic usage, but you can build and run it with `npm start` inside
+that folder.

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Simple Chat App</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    #chat { border: 1px solid #ccc; height: 300px; overflow-y: auto; padding: 10px; margin-bottom: 10px; }
+    #chat div { margin-bottom: 5px; }
+  </style>
+</head>
+<body>
+  <h2>Simple Chat Room</h2>
+  <input id="room" placeholder="Room name" />
+  <button id="join">Join Room</button>
+  <div id="chat"></div>
+  <input id="message" placeholder="Type a message" />
+  <button id="send">Send</button>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const socket = io();
+    const roomInput = document.getElementById('room');
+    const joinBtn = document.getElementById('join');
+    const chatDiv = document.getElementById('chat');
+    const msgInput = document.getElementById('message');
+    const sendBtn = document.getElementById('send');
+    let currentRoom = '';
+
+    joinBtn.onclick = () => {
+      const room = roomInput.value.trim();
+      if (room) {
+        currentRoom = room;
+        socket.emit('joinRoom', room);
+        appendMessage('BOT', `Joined room ${room}`);
+      }
+    };
+
+    sendBtn.onclick = () => {
+      const msg = msgInput.value.trim();
+      if (msg && currentRoom) {
+        socket.emit('chatMessage', { room: currentRoom, message: msg });
+        appendMessage('You', msg);
+        msgInput.value = '';
+      }
+    };
+
+    socket.on('chatMessage', data => {
+      appendMessage(data.sender, data.message);
+    });
+
+    socket.on('userJoined', msg => {
+      appendMessage('BOT', msg);
+    });
+
+    function appendMessage(sender, message) {
+      const div = document.createElement('div');
+      div.innerHTML = `<strong>${sender}:</strong> ${message}`;
+      chatDiv.appendChild(div);
+      chatDiv.scrollTop = chatDiv.scrollHeight;
+    }
+  </script>
+</body>
+</html>

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,8 @@ import { Server } from 'socket.io';
 
 const app = express();
 const httpServer = createServer(app);
+// Serve static files for a simple built-in GUI
+app.use(express.static('./public'));
 const io = new Server( httpServer, {
     cors: { origin: '*' }
 });
@@ -31,5 +33,5 @@ io.on('connection', (socket) => {
 
 
 httpServer.listen(3000, () => {
-  console.log('🚀 Server listening on http://localhost:3000');
+  console.log('🚀 Server listening on port 3000');
 });


### PR DESCRIPTION
## Summary
- add a minimal static chat UI served from the backend
- expose the static files via Express
- update server log message
- document how to run and access the app

## Testing
- `npm test` in `backend` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d567047c8333839cd44e6dd6f120